### PR TITLE
Feature/add historic sesnor data to paa #16

### DIFF
--- a/build/lib/purpleair_data_logger/PurpleAirAPI.py
+++ b/build/lib/purpleair_data_logger/PurpleAirAPI.py
@@ -8,7 +8,18 @@
 
 import requests
 import json
-from purpleair_data_logger.PurpleAirAPIConstants import ACCEPTED_FIELD_NAMES_DICT, PRINT_DEBUG_MSGS
+from purpleair_data_logger.PurpleAirAPIConstants import (
+    ACCEPTED_FIELD_NAMES_DICT, PRINT_DEBUG_MSGS, SUCCESS_CODE_LIST, ERROR_CODES_LIST)
+
+
+class PurpleAirAPIError(Exception):
+    """ 
+        Custom Exception for our PurpleAirAPI class.
+    """
+
+    def __init__(self, message_string):
+        self.message = message_string
+        super().__init__(self.message)
 
 
 def debug_log(debug_msg_string):
@@ -55,10 +66,11 @@ class PurpleAirAPI():
         my_request = requests.get(request_url, headers={
                                   "X-API-Key": str(self._your_api_read_key)})
 
-        if my_request.status_code == 201:
+        the_request_text_as_json = json.loads(my_request.text)
+        debug_log(the_request_text_as_json)
+
+        if my_request.status_code in SUCCESS_CODE_LIST:
             # We good :) get the request text
-            the_request_text_as_json = json.loads(my_request.text)
-            debug_log(the_request_text_as_json)
             self._api_version = the_request_text_as_json["api_version"]
             self._api_key_last_checked = the_request_text_as_json["time_stamp"]
             self._api_key_type = the_request_text_as_json["api_key_type"]
@@ -67,8 +79,8 @@ class PurpleAirAPI():
             return True
 
         else:
-            raise ValueError(
-                f"Invalid API Key provided: {self._your_api_read_key}")
+            raise PurpleAirAPIError(
+                f"""{my_request.status_code}: {the_request_text_as_json['error']} - {the_request_text_as_json['description']}""")
 
     def recheck_api_key(self):
         """
@@ -131,36 +143,12 @@ class PurpleAirAPI():
         request_url = self._base_api_request_string + \
             "sensors/" + f"{sensor_index}"
 
-        # Add to the request_url string depending on what optional parameters are
-        # passed in
-        if read_key is not None and fields is not None:
-            request_url = request_url + \
-                f"?read_key={str(read_key)}&fields={str(fields)}"
+        optional_parameters_dict = {
+            "read_key": read_key,
+            "fields": fields
+        }
 
-        elif read_key is None and fields is not None:
-            request_url = request_url + f"?fields={str(fields)}"
-
-        elif read_key is not None and fields is None:
-            request_url = request_url + f"?read_key={str(read_key)}"
-
-        debug_log(request_url)
-        my_request = requests.get(request_url, headers={
-                                  "X-API-Key": str(self._your_api_read_key)})
-
-        if my_request.status_code == 200:
-            # We good :) get the request text
-            the_request_text_as_json = json.loads(my_request.text)
-            debug_log(the_request_text_as_json)
-            my_request.close()
-            del my_request
-            return self._sanitize_sensor_data_from_paa(the_request_text_as_json)
-
-        elif my_request.status_code == 400:
-            the_request_text_as_json = json.loads(my_request.text)
-            debug_log(the_request_text_as_json)
-            my_request.close()
-            raise ValueError(
-                f"{the_request_text_as_json['error']} - {the_request_text_as_json['description']}")
+        return self._send_url_request(request_url, optional_parameters_dict)
 
     def request_multiple_sensors_data(self, fields, location_type=None, read_keys=None, show_only=None, modified_since=None, max_age=None, nwlng=None, nwlat=None, selng=None, selat=None):
         """
@@ -246,32 +234,111 @@ class PurpleAirAPI():
             "selng": selng,
             "selat": selat}
 
-        for opt_param, val in optional_parameters_dict.items():
+        return self._send_url_request(request_url, optional_parameters_dict)
 
-            # We haven't added any yet. The first one will look different that
-            # the rest
-            if opt_param is None:
-                request_url = request_url + \
-                    f"&{opt_param}={str(val)}"
+    def request_sensor_historic_data(self, sensor_index, fields, read_key=None, start_timestamp=None, end_timestamp=None, average=None):
+        """
+            A method to request historic data from a single sensor.
+
+            :param int sensor_index: The sensor_index as found in the JSON for this specific sensor.
+
+            :param (optional) str read_key: This read_key is required for private devices. It is separate to the api_key and each sensor has its own read_key. Submit multiple keys by separating them with a comma (,) character for example: key-one,key-two,key-three.
+
+            :param (optional) int start_timestamp: The time stamp of the first required history entry. Query is executed using data_timestamp >= start_timestamp.
+                                                   Time can be specified as a UNIX time stamp in seconds or an ISO 8601 string. https://en.wikipedia.org/wiki/ISO_8601.
+                                                   The time_stamp column in the resulting JSON or CSV will be in the same format and or time zone that you use for this start_timestamp parameter.
+                                                   If not specified, the last maximum time span for the requested average will be returned.
+
+            :param (optional) int end_timestamp: The end time stamp of the history to return. Query is executed using data_timestamp < end_timestamp.
+                                                 Time can be specified as a UNIX time stamp in seconds or an ISO 8601 string. https://en.wikipedia.org/wiki/ISO_8601.
+                                                 If not specified, the maximum time span will be returned starting from the provided start_timestamp.
+
+            :param (optional) int average: The desired average in minutes, one of the following: 0 (real-time), 10 (default if not specified), 30, 60, 360 (6 hour), 1440 (1 day)
+                                           Coming soon: 10080 (1 week), 44640 (1 month), 525600 (1 year).
+
+            :param str fields: The 'Fields' parameter specifies which 'sensor data fields' to include in the response. Not all fields are available as history fields and we will be working to add more as time goes on. Fields marked with an asterisk (*) may not be available when using averages. It is a comma separated list with one or more of the following:
+
+                               Station information and status fields:
+                               hardware*, latitude*, longitude*, altitude*, firmware_version*, rssi, uptime, pa_latency, memory,
+
+                               Environmental fields:
+                               humidity, humidity_a, humidity_b, temperature, temperature_a, temperature_b, pressure, pressure_a, pressure_b
+
+                               Miscellaneous fields:
+                               voc, voc_a, voc_b, analog_input
+
+                               PM1.0 fields:
+                               pm1.0_atm, pm1.0_atm_a, pm1.0_atm_b, pm1.0_cf_1, pm1.0_cf_1_a, pm1.0_cf_1_b
+
+                               PM2.5 fields:
+                               pm2.5_alt, pm2.5_alt_a, pm2.5_alt_b, pm2.5_atm, pm2.5_atm_a, pm2.5_atm_b, pm2.5_cf_1, pm2.5_cf_1_a, pm2.5_cf_1_b
+
+                               PM10.0 fields:
+                               pm10.0_atm, pm10.0_atm_a, pm10.0_atm_b, pm10.0_cf_1, pm10.0_cf_1_a, pm10.0_cf_1_b
+
+                               Visibility fields:
+                               scattering_coefficient, scattering_coefficient_a, scattering_coefficient_b, deciviews, deciviews_a, deciviews_b, visual_range, visual_range_a, visual_range_b
+
+                               Particle count fields:
+                               0.3_um_count, 0.3_um_count_a, 0.3_um_count_b, 0.5_um_count, 0.5_um_count_a, 0.5_um_count_b, 1.0_um_count, 1.0_um_count_a, 1.0_um_count_b, 2.5_um_count, 2.5_um_count_a, 2.5_um_count_b, 5.0_um_count, 5.0_um_count_a, 5.0_um_count_b, 10.0_um_count, 10.0_um_count_a, 10.0_um_count_b
+
+                               For field descriptions, please see the 'sensor data fields'. section.
+        """
+
+        request_url = self._base_api_request_string + \
+            "sensors/" + f"{sensor_index}" + "/history" + f"?fields={fields}"
+
+        # Add to the request_url string depending on what optional parameters are
+        # passed in. Turn them into a list of optional parameters
+        optional_parameters_dict = {
+            "read_key": read_key,
+            "start_timestamp": start_timestamp,
+            "end_timestamp": end_timestamp,
+            "modified_since": end_timestamp,
+            "average": average}
+
+        return self._send_url_request(request_url, optional_parameters_dict)
+
+    def _send_url_request(self, request_url, optional_parameters_dict={}):
+        """
+            A class helper to send the url request. It can also add onto the
+            'request_url' string if 'optional_parameters_dict' are provided.
+
+            :param str request_url: The constructed string url request string.
+            :param dict optional_parameters_dict: Optional parameters that can be added onto the
+                                                  request_url. By default '{}'.
+        """
+
+        if optional_parameters_dict is not {}:
+            opt_param_count = 0
+            for opt_param, val in optional_parameters_dict.items():
+                if val is not None:
+                    opt_param_count = opt_param_count + 1
+
+                    if opt_param_count == 1:
+                        request_url = request_url + \
+                            f"?{opt_param}={str(val)}"
+
+                    elif opt_param_count >= 2:
+                        request_url = request_url + \
+                            f"&{opt_param}={str(val)}"
 
         debug_log(request_url)
         my_request = requests.get(request_url, headers={
                                   "X-API-Key": str(self._your_api_read_key)})
 
-        if my_request.status_code == 200:
-            # We good :) get the request text
-            the_request_text_as_json = json.loads(my_request.text)
-            debug_log(the_request_text_as_json)
+        the_request_text_as_json = json.loads(my_request.text)
+        debug_log(the_request_text_as_json)
+
+        if my_request.status_code in SUCCESS_CODE_LIST:
             my_request.close()
             del my_request
             return the_request_text_as_json
 
-        elif my_request.status_code == 400:
-            the_request_text_as_json = json.loads(my_request.text)
-            debug_log(the_request_text_as_json)
+        elif my_request.status_code in ERROR_CODES_LIST:
             my_request.close()
-            raise ValueError(
-                f"{the_request_text_as_json['error']} - {the_request_text_as_json['description']}")
+            raise PurpleAirAPIError(
+                f"""{my_request.status_code}: {the_request_text_as_json['error']} - {the_request_text_as_json['description']}""")
 
     def _sanitize_sensor_data_from_paa(self, paa_return_data):
         """

--- a/build/lib/purpleair_data_logger/PurpleAirAPIConstants.py
+++ b/build/lib/purpleair_data_logger/PurpleAirAPIConstants.py
@@ -6,7 +6,13 @@
 """
 
 #: A constant to see if debug statements are enabled in the PurpleAirAPI module.
-PRINT_DEBUG_MSGS = False
+PRINT_DEBUG_MSGS = True
+
+#: Accepted Error Codes
+ERROR_CODES_LIST = [400, 403, 404]
+
+#: Success Code
+SUCCESS_CODE_LIST = [200, 201]
 
 #: Store the dict/json keys to access data fields.
 #: And define default empty/null values for them

--- a/purpleair_data_logger/PurpleAirAPI.py
+++ b/purpleair_data_logger/PurpleAirAPI.py
@@ -273,6 +273,56 @@ class PurpleAirAPI():
             raise ValueError(
                 f"{the_request_text_as_json['error']} - {the_request_text_as_json['description']}")
 
+    def request_sensor_historic_data(self, sensor_index, read_key, start_timestamp, end_timestamp, average, fields):
+        """
+            A method to BLA FILL ME IN
+
+            :param int sensor_index: The sensor_index as found in the JSON for this specific sensor.
+
+            :param (optional) str read_key: This read_key is required for private devices. It is separate to the api_key and each sensor has its own read_key. Submit multiple keys by separating them with a comma (,) character for example: key-one,key-two,key-three.
+
+            :param (optional) int start_timestamp: The time stamp of the first required history entry. Query is executed using data_timestamp >= start_timestamp.
+                                                   Time can be specified as a UNIX time stamp in seconds or an ISO 8601 string. https://en.wikipedia.org/wiki/ISO_8601.
+                                                   The time_stamp column in the resulting JSON or CSV will be in the same format and or time zone that you use for this start_timestamp parameter.
+                                                   If not specified, the last maximum time span for the requested average will be returned.
+
+            :param (optional) int end_timestamp: The end time stamp of the history to return. Query is executed using data_timestamp < end_timestamp.
+                                                 Time can be specified as a UNIX time stamp in seconds or an ISO 8601 string. https://en.wikipedia.org/wiki/ISO_8601.
+                                                 If not specified, the maximum time span will be returned starting from the provided start_timestamp.
+
+            :param (optional) int average: The desired average in minutes, one of the following: 0 (real-time), 10 (default if not specified), 30, 60, 360 (6 hour), 1440 (1 day)
+                                           Coming soon: 10080 (1 week), 44640 (1 month), 525600 (1 year).
+
+            :param str fields: The 'Fields' parameter specifies which 'sensor data fields' to include in the response. Not all fields are available as history fields and we will be working to add more as time goes on. Fields marked with an asterisk (*) may not be available when using averages. It is a comma separated list with one or more of the following:
+
+                               Station information and status fields:
+                               hardware*, latitude*, longitude*, altitude*, firmware_version*, rssi, uptime, pa_latency, memory,
+
+                               Environmental fields:
+                               humidity, humidity_a, humidity_b, temperature, temperature_a, temperature_b, pressure, pressure_a, pressure_b
+
+                               Miscellaneous fields:
+                               voc, voc_a, voc_b, analog_input
+
+                               PM1.0 fields:
+                               pm1.0_atm, pm1.0_atm_a, pm1.0_atm_b, pm1.0_cf_1, pm1.0_cf_1_a, pm1.0_cf_1_b
+
+                               PM2.5 fields:
+                               pm2.5_alt, pm2.5_alt_a, pm2.5_alt_b, pm2.5_atm, pm2.5_atm_a, pm2.5_atm_b, pm2.5_cf_1, pm2.5_cf_1_a, pm2.5_cf_1_b
+
+                               PM10.0 fields:
+                               pm10.0_atm, pm10.0_atm_a, pm10.0_atm_b, pm10.0_cf_1, pm10.0_cf_1_a, pm10.0_cf_1_b
+
+                               Visibility fields:
+                               scattering_coefficient, scattering_coefficient_a, scattering_coefficient_b, deciviews, deciviews_a, deciviews_b, visual_range, visual_range_a, visual_range_b
+
+                               Particle count fields:
+                               0.3_um_count, 0.3_um_count_a, 0.3_um_count_b, 0.5_um_count, 0.5_um_count_a, 0.5_um_count_b, 1.0_um_count, 1.0_um_count_a, 1.0_um_count_b, 2.5_um_count, 2.5_um_count_a, 2.5_um_count_b, 5.0_um_count, 5.0_um_count_a, 5.0_um_count_b, 10.0_um_count, 10.0_um_count_a, 10.0_um_count_b
+
+                               For field descriptions, please see the 'sensor data fields'. section.
+        """
+        pass
+
     def _sanitize_sensor_data_from_paa(self, paa_return_data):
         """
             A method for: Not all sensors support all field names, so we check that the keys exist

--- a/purpleair_data_logger/PurpleAirAPIConstants.py
+++ b/purpleair_data_logger/PurpleAirAPIConstants.py
@@ -8,6 +8,12 @@
 #: A constant to see if debug statements are enabled in the PurpleAirAPI module.
 PRINT_DEBUG_MSGS = False
 
+#: Accepted Error Codes
+ERROR_CODES_LIST = [400,404]
+
+#: Success Code
+SUCCESS_CODE = 200
+
 #: Store the dict/json keys to access data fields.
 #: And define default empty/null values for them
 #: These keys are derived from the PurpleAir documentation: https://api.purpleair.com/#api-sensors-get-sensor-data

--- a/purpleair_data_logger/PurpleAirAPIConstants.py
+++ b/purpleair_data_logger/PurpleAirAPIConstants.py
@@ -9,10 +9,10 @@
 PRINT_DEBUG_MSGS = False
 
 #: Accepted Error Codes
-ERROR_CODES_LIST = [400,404]
+ERROR_CODES_LIST = [400, 403, 404]
 
 #: Success Code
-SUCCESS_CODE = 200
+SUCCESS_CODE_LIST = [200, 201]
 
 #: Store the dict/json keys to access data fields.
 #: And define default empty/null values for them


### PR DESCRIPTION
Adds the ability to retrieve historic sensor data from the PurpleAirAPI.
Although it seems that this ability has been disabled...
![Screen Shot 2022-09-10 at 4 49 45 PM](https://user-images.githubusercontent.com/27721404/189501263-d30b092a-7421-442b-851d-d554e359c7b4.png)
